### PR TITLE
accept empty transform object

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -322,6 +322,35 @@ hash:0:doc.pdf:0:1
       expect(cont).toEqual(content);
     });
 
+    test("handles empty transform object", async () => {
+      const realHash = repHash("1");
+      const file = `3
+${realHash}:0:doc.content:0:1
+hash:0:doc.metadata:0:1
+hash:0:doc.pdf:0:1
+`;
+      const content = {
+        fileType: "pdf",
+        coverPageNumber: -1,
+        documentMetadata: {},
+        extraMetadata: {},
+        fontName: "",
+        lineHeight: -1,
+        orientation: "portrait",
+        pageCount: 1,
+        sizeInBytes: "1",
+        textAlignment: "left",
+        textScale: 1,
+        transform: {},
+      } as unknown as DocumentContent;
+      mockFetch(emptyResponse(), textResponse(file), jsonResponse(content));
+
+      const api = await remarkable("");
+      const cont = (await api.getContent(repHash("0"))) as DocumentContent;
+      expect(cont.fileType).toBe("pdf");
+      expect(cont.transform ?? {}).toEqual({});
+    });
+
     test("TemplateType", async () => {
       const realHash = repHash("1");
       const file = `3

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -329,7 +329,7 @@ ${realHash}:0:doc.content:0:1
 hash:0:doc.metadata:0:1
 hash:0:doc.pdf:0:1
 `;
-      const content = {
+      const content: DocumentContent = {
         fileType: "pdf",
         coverPageNumber: -1,
         documentMetadata: {},
@@ -342,7 +342,7 @@ hash:0:doc.pdf:0:1
         textAlignment: "left",
         textScale: 1,
         transform: {},
-      } as unknown as DocumentContent;
+      };
       mockFetch(emptyResponse(), textResponse(file), jsonResponse(content));
 
       const api = await remarkable("");

--- a/src/raw.ts
+++ b/src/raw.ts
@@ -438,7 +438,7 @@ export interface DocumentContent {
   /** what zoom mode is set for the page */
   zoomMode?: ZoomMode;
   /** [speculative] a transform matrix, a. la. css matrix transform */
-  transform?: Record<`m${"1" | "2" | "3"}${"1" | "2" | "3"}`, number>;
+  transform?: Partial<Record<`m${"1" | "2" | "3"}${"1" | "2" | "3"}`, number>>;
   /** [speculative] metadata about keyboard use */
   keyboardMetadata?: KeyboardMetadata;
   /** [speculative] various other page metadata */
@@ -492,6 +492,7 @@ const documentContent = properties(
     redirectionPageMap: elements(int32()),
     tags: elements(tag),
     transform: properties(
+      undefined,
       {
         m11: float64(),
         m12: float64(),
@@ -503,7 +504,6 @@ const documentContent = properties(
         m32: float64(),
         m33: float64(),
       },
-      undefined,
       true,
     ),
     // eslint-disable-next-line spellcheck/spell-checker
@@ -1072,32 +1072,6 @@ export class RawRemarkable implements RawRemarkableApi {
   async getContent(hash: string): Promise<Content> {
     const raw = await this.getText(hash);
     const loaded = JSON.parse(raw) as unknown;
-
-    // Normalize empty transform object before validation
-    // reMarkable API returns transform: {} for some documents, but schema requires
-    // all matrix properties (m11-m33) when transform is present
-    if (
-      loaded &&
-      typeof loaded === "object" &&
-      "fileType" in loaded &&
-      "transform" in loaded
-    ) {
-      const doc = loaded as { transform?: unknown };
-      const transform = doc.transform;
-      if (
-        transform &&
-        typeof transform === "object" &&
-        !Array.isArray(transform)
-      ) {
-        const proto = Object.getPrototypeOf(transform);
-        if (
-          (proto === Object.prototype || proto === null) &&
-          Object.keys(transform).length === 0
-        ) {
-          delete doc.transform;
-        }
-      }
-    }
 
     // jtd can't verify non-discriminated unions, in this case, we have fileType
     // defined or not. As a result, we try each, and concatenate the errors at the end


### PR DESCRIPTION
here is what codex and me came up with around deleting the empty transform vs. allowing an object with missing keys:

A 3×3 transform matrix is only meaningful when all 9 entries are present; missing any entries makes the transform undefined (you can’t reliably scale/rotate/translate or invert it). There’s no code or schema defaults here that define how to interpret missing keys, so partial matrices would introduce ambiguous/invalid states. An empty object, by contrast, clearly means “no transform,” which is equivalent to the field being absent.

I cannot come up with any idea on how to handle it different in the schema either, so implementation removes empty transform objects.