### PR TITLE
fix: send rm-filename on v3 file GETs/PUTs with full filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- methods now take an id or filename that's necessary for rm header validation, this is a breaking change, but also one that is broken already.
+
 ## [9.0.0] - 2025-12-07
 
 ### Added

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -232,7 +232,7 @@ hash:0:doc.pdf:0:1
     mockFetch(emptyResponse(), textResponse(file), jsonResponse(metadata));
 
     const api = await remarkable("");
-    const meta = await api.getMetadata(repHash("0"));
+    const meta = await api.getMetadata("test-id", repHash("0"));
     expect(meta).toEqual(metadata);
   });
 
@@ -290,7 +290,7 @@ hash:0:doc.pdf:0:1
       mockFetch(emptyResponse(), textResponse(file), jsonResponse(content));
 
       const api = await remarkable("");
-      const cont = await api.getContent(repHash("0"));
+      const cont = await api.getContent("test-id", repHash("0"));
       expect(cont).toEqual(content);
     });
 
@@ -318,7 +318,10 @@ hash:0:doc.pdf:0:1
       mockFetch(emptyResponse(), textResponse(file), jsonResponse(content));
 
       const api = await remarkable("");
-      const cont = (await api.getContent(repHash("0"))) as DocumentContent;
+      const cont = (await api.getContent(
+        "test-id",
+        repHash("0"),
+      )) as DocumentContent;
       expect(cont).toEqual(content);
     });
 
@@ -346,7 +349,10 @@ hash:0:doc.pdf:0:1
       mockFetch(emptyResponse(), textResponse(file), jsonResponse(content));
 
       const api = await remarkable("");
-      const cont = (await api.getContent(repHash("0"))) as DocumentContent;
+      const cont = (await api.getContent(
+        "test-id",
+        repHash("0"),
+      )) as DocumentContent;
       expect(cont.fileType).toBe("pdf");
       expect(cont.transform ?? {}).toEqual({});
     });
@@ -381,7 +387,7 @@ hash:0:tpl.template:0:1
       mockFetch(emptyResponse(), textResponse(file), jsonResponse(content));
 
       const api = await remarkable("");
-      const cont = await api.getContent(repHash("0"));
+      const cont = await api.getContent("test-id", repHash("0"));
       expect(cont).toEqual(content);
     });
 
@@ -399,7 +405,7 @@ hash:0:doc.epub:0:1
       );
 
       const api = await remarkable("");
-      expect(api.getContent(repHash("0"))).rejects.toThrow("\nor\n");
+      expect(api.getContent("test-id", repHash("0"))).rejects.toThrow("\nor\n");
     });
   });
 
@@ -421,7 +427,7 @@ hash:0:doc.pdf:0:1
     mockFetch(emptyResponse(), textResponse(file), jsonResponse(metadata));
 
     const api = await remarkable("");
-    const meta = await api.getMetadata(repHash("0"));
+    const meta = await api.getMetadata("test-id", repHash("0"));
     expect(meta).toEqual(metadata);
   });
   test("#getPdf()", async () => {
@@ -437,7 +443,7 @@ ${realHash}:0:doc.pdf:0:1
     mockFetch(emptyResponse(), textResponse(file), bytesResponse(pdf));
 
     const api = await remarkable("");
-    const bytes = await api.getPdf(repHash("0"));
+    const bytes = await api.getPdf("test-id", repHash("0"));
     expect(bytes).toEqual(pdf);
   });
 
@@ -454,7 +460,7 @@ hash:0:doc.pdf:0:1
     mockFetch(emptyResponse(), textResponse(file), bytesResponse(epub));
 
     const api = await remarkable("");
-    const bytes = await api.getEpub(repHash("0"));
+    const bytes = await api.getEpub("test-id", repHash("0"));
     expect(bytes).toEqual(epub);
   });
 
@@ -500,7 +506,7 @@ ${epubHash}:0:doc.epub:0:1
     );
 
     const api = await remarkable("");
-    const bytes = await api.getDocument(repHash("0"));
+    const bytes = await api.getDocument("test-id", repHash("0"));
     expect(bytes.length).toBeGreaterThan(0);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -409,10 +409,11 @@ export interface RemarkableApi {
    * the low-level api to get the raw text of the `.content` file in the
    * `RawEntry` for this hash.
    *
+   * @param id - the id of the item (as returned by `listIds`)
    * @param hash - the hash of the item to get content for
    * @returns the content
    */
-  getContent(hash: string): Promise<Content>;
+  getContent(id: string, hash: string): Promise<Content>;
 
   /**
    * get the metadata from an item hash
@@ -425,32 +426,35 @@ export interface RemarkableApi {
    * the low-level api to get the raw text of the `.metadata` file in the
    * `RawEntry` for this hash.
    *
+   * @param id - the id of the item (as returned by `listIds`)
    * @param hash - the hash of the item to get metadata for
    * @returns the metadata
    */
-  getMetadata(hash: string): Promise<Metadata>;
+  getMetadata(id: string, hash: string): Promise<Metadata>;
 
   /**
    * get the pdf associated with a document hash
    *
    * This returns the raw input pdf, not the rendered pdf with any markup.
    *
+   * @param id - the id of the document (as returned by `listIds`)
    * @param hash - the hash of the document to get the pdf for (e.g. the hash
    *     received from `listItems`)
    * @returns the pdf bytes
    */
-  getPdf(hash: string): Promise<Uint8Array>;
+  getPdf(id: string, hash: string): Promise<Uint8Array>;
 
   /**
    * get the epub associated with a document hash
    *
    * This returns the raw input epub if a document was created from an epub.
    *
-   * @param hash - the hash of the document to get the pdf for (e.g. the hash
+   * @param id - the id of the document (as returned by `listIds`)
+   * @param hash - the hash of the document to get the epub for (e.g. the hash
    *     received from `listItems`)
    * @returns the epub bytes
    */
-  getEpub(hash: string): Promise<Uint8Array>;
+  getEpub(id: string, hash: string): Promise<Uint8Array>;
 
   /**
    * get the entire contents of a remarkable document
@@ -463,10 +467,11 @@ export interface RemarkableApi {
    * of the document, but this format isn't understood enoguh to reput this on a
    * different remarkable, so that functionality is currently disabled.
    *
-   * @param hash - the hash of the document to get the contents for (e.g. the
+   * @param id - the id of the document (as returned by `listIds`)
+   * @param hash - the hash of the document to get contents for (e.g. the
    *    hash received from `listItems`)
    */
-  getDocument(hash: string): Promise<Uint8Array>;
+  getDocument(id: string, hash: string): Promise<Uint8Array>;
 
   /**
    * use the low-level api to add a pdf document
@@ -807,7 +812,7 @@ class Remarkable implements RemarkableApi {
   }
 
   async #convertEntry({ hash, id }: SimpleEntry): Promise<Entry> {
-    const { entries } = await this.raw.getEntries(hash);
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const metaEnt = entries.find((ent) => ent.id.endsWith(".metadata"));
     const contentEnt = entries.find((ent) => ent.id.endsWith(".content"));
     if (metaEnt === undefined) {
@@ -826,11 +831,11 @@ class Remarkable implements RemarkableApi {
       },
       content,
     ] = await Promise.all([
-      this.raw.getMetadata(metaEnt.hash),
+      this.raw.getMetadata(metaEnt.id, metaEnt.hash),
       // collections don't always have content, since content only lists tags
       contentEnt === undefined
         ? Promise.resolve({ fileType: undefined, tags: undefined })
-        : this.raw.getContent(contentEnt.hash),
+        : this.raw.getContent(contentEnt.id, contentEnt.hash),
     ]);
     if ("templateVersion" in content) {
       return {
@@ -879,56 +884,56 @@ class Remarkable implements RemarkableApi {
 
   async listIds(refresh: boolean = false): Promise<SimpleEntry[]> {
     const [hash] = await this.#getRootHash(refresh);
-    const { entries } = await this.raw.getEntries(hash);
+    const { entries } = await this.raw.getEntries("root.docSchema", hash);
     return entries.map(({ id, hash }) => ({ id, hash }));
   }
 
-  async getContent(hash: string): Promise<Content> {
-    const { entries } = await this.raw.getEntries(hash);
+  async getContent(id: string, hash: string): Promise<Content> {
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const [cont] = entries.filter((e) => e.id.endsWith(".content"));
     if (cont === undefined) {
       throw new Error(`couldn't find contents for hash ${hash}`);
     } else {
-      return await this.raw.getContent(cont.hash);
+      return await this.raw.getContent(cont.id, cont.hash);
     }
   }
 
-  async getMetadata(hash: string): Promise<Metadata> {
-    const { entries } = await this.raw.getEntries(hash);
+  async getMetadata(id: string, hash: string): Promise<Metadata> {
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const [meta] = entries.filter((e) => e.id.endsWith(".metadata"));
     if (meta === undefined) {
       throw new Error(`couldn't find metadata for hash ${hash}`);
     } else {
-      return await this.raw.getMetadata(meta.hash);
+      return await this.raw.getMetadata(meta.id, meta.hash);
     }
   }
 
-  async getPdf(hash: string): Promise<Uint8Array> {
-    const { entries } = await this.raw.getEntries(hash);
+  async getPdf(id: string, hash: string): Promise<Uint8Array> {
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const [pdf] = entries.filter((e) => e.id.endsWith(".pdf"));
     if (pdf === undefined) {
       throw new Error(`couldn't find pdf for hash ${hash}`);
     } else {
-      return await this.raw.getHash(pdf.hash);
+      return await this.raw.getHash(pdf.id, pdf.hash);
     }
   }
 
-  async getEpub(hash: string): Promise<Uint8Array> {
-    const { entries } = await this.raw.getEntries(hash);
+  async getEpub(id: string, hash: string): Promise<Uint8Array> {
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const [epub] = entries.filter((e) => e.id.endsWith(".epub"));
     if (epub === undefined) {
       throw new Error(`couldn't find epub for hash ${hash}`);
     } else {
-      return await this.raw.getHash(epub.hash);
+      return await this.raw.getHash(epub.id, epub.hash);
     }
   }
 
-  async getDocument(hash: string): Promise<Uint8Array> {
-    const { entries } = await this.raw.getEntries(hash);
+  async getDocument(id: string, hash: string): Promise<Uint8Array> {
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const zip = new JSZip();
     for (const entry of entries) {
       // TODO if this is .metadata we might want to assert type === "DocumentType"
-      zip.file(entry.id, this.raw.getHash(entry.hash));
+      zip.file(entry.id, this.raw.getHash(entry.id, entry.hash));
     }
     return zip.generateAsync({ type: "uint8array" });
   }
@@ -1026,7 +1031,7 @@ class Remarkable implements RemarkableApi {
           [contentEntry, metadataEntry, pagedataEntry, fileEntry],
           schemaVersion,
         ),
-        this.raw.getEntries(rootHash),
+        this.raw.getEntries("root.docSchema", rootHash),
       ]);
 
     // now upload a new root entry
@@ -1113,7 +1118,7 @@ class Remarkable implements RemarkableApi {
     const [[collectionEntry, uploadCollection], { entries: rootEntries }] =
       await Promise.all([
         this.raw.putEntries(id, [contentEntry, metadataEntry], schemaVersion),
-        this.raw.getEntries(rootHash),
+        this.raw.getEntries("root.docSchema", rootHash),
       ]);
 
     // now upload a new root entry
@@ -1169,13 +1174,13 @@ class Remarkable implements RemarkableApi {
     update: Partial<Content>,
     schemaVersion: SchemaVersion,
   ): Promise<[RawEntry, Promise<[void, void]>]> {
-    const { entries } = await this.raw.getEntries(hash);
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const contInd = entries.findIndex((ent) => ent.id.endsWith(".content"));
     const contEntry = entries[contInd];
     if (contEntry === undefined) {
       throw new Error("internal error: couldn't find content in entry hash");
     }
-    const cont = await this.raw.getContent(contEntry.hash);
+    const cont = await this.raw.getContent(contEntry.id, contEntry.hash);
     Object.assign(cont, update);
     const [newContEntry, uploadCont] = await this.raw.putContent(
       contEntry.id,
@@ -1200,7 +1205,7 @@ class Remarkable implements RemarkableApi {
   ): Promise<HashEntry> {
     const [rootHash, generation, schemaVersion] =
       await this.#getRootHash(refresh);
-    const { entries } = await this.raw.getEntries(rootHash);
+    const { entries } = await this.raw.getEntries("root.docSchema", rootHash);
     const hashInd = entries.findIndex((ent) => ent.hash === hash);
     const hashEnt = entries[hashInd];
     if (hashEnt === undefined) {
@@ -1209,7 +1214,7 @@ class Remarkable implements RemarkableApi {
 
     const [[newEnt, uploadEnt], meta] = await Promise.all([
       this.#editContentRaw(hashEnt.id, hash, update, schemaVersion),
-      this.getMetadata(hash),
+      this.getMetadata(hashEnt.id, hash),
     ]);
     if (meta.type !== expectedType) {
       throw new Error(
@@ -1262,13 +1267,13 @@ class Remarkable implements RemarkableApi {
     update: Partial<Metadata>,
     schemaVersion: SchemaVersion,
   ): Promise<[RawEntry, Promise<[void, void]>]> {
-    const { entries } = await this.raw.getEntries(hash);
+    const { entries } = await this.raw.getEntries(`${id}.docSchema`, hash);
     const metaInd = entries.findIndex((ent) => ent.id.endsWith(".metadata"));
     const metaEntry = entries[metaInd];
     if (metaEntry === undefined) {
       throw new Error("internal error: couldn't find metadata in entry hash");
     }
-    const meta = await this.raw.getMetadata(metaEntry.hash);
+    const meta = await this.raw.getMetadata(metaEntry.id, metaEntry.hash);
     Object.assign(meta, update);
     const [newMetaEntry, uploadMeta] = await this.raw.putMetadata(
       metaEntry.id,
@@ -1291,7 +1296,7 @@ class Remarkable implements RemarkableApi {
   ): Promise<HashEntry> {
     const [rootHash, generation, schemaVersion] =
       await this.#getRootHash(refresh);
-    const { entries } = await this.raw.getEntries(rootHash);
+    const { entries } = await this.raw.getEntries("root.docSchema", rootHash);
     const hashInd = entries.findIndex((ent) => ent.hash === hash);
     const hashEnt = entries[hashInd];
     if (hashEnt === undefined) {
@@ -1371,7 +1376,7 @@ class Remarkable implements RemarkableApi {
 
     const [rootHash, generation, schemaVersion] =
       await this.#getRootHash(refresh);
-    const { entries } = await this.raw.getEntries(rootHash);
+    const { entries } = await this.raw.getEntries("root.docSchema", rootHash);
 
     const hashSet = new Set(hashes);
     const toUpdate: RawEntry[] = [];
@@ -1427,15 +1432,15 @@ class Remarkable implements RemarkableApi {
     // should only go one step) to track all hashes encountered
     // NOTE that we could increase the cache in this process, or it's possible
     // for other calls to increase the cache with misc values.
-    const base = await this.raw.getEntries(rootHash);
+    const base = await this.raw.getEntries("root.docSchema", rootHash);
     let entries = [base.entries];
     let nextEntries: Promise<Entries>[] = [];
     while (entries.length) {
       for (const entryList of entries) {
-        for (const { hash, type } of entryList) {
+        for (const { hash, type, id } of entryList) {
           toDelete.add(hash);
           if (type === 80000000) {
-            nextEntries.push(this.raw.getEntries(hash));
+            nextEntries.push(this.raw.getEntries(`${id}.docSchema`, hash));
           }
         }
       }

--- a/src/raw.ts
+++ b/src/raw.ts
@@ -767,10 +767,13 @@ export interface RawRemarkableApi {
   /**
    * get the raw binary data associated with a hash
    *
+   * @param fileName - the logical file name (`<id>.<ext>` for files, or
+   *   `<id>.docSchema` / `"root.docSchema"` for entry indexes). reMarkable
+   *   validates this against the rm-filename header.
    * @param hash - the hash to get the data for
    * @returns the data
    */
-  getHash(hash: string): Promise<Uint8Array>;
+  getHash(fileName: string, hash: string): Promise<Uint8Array>;
 
   /**
    * get raw text data associated with a hash
@@ -778,10 +781,11 @@ export interface RawRemarkableApi {
    * We assume text data are small, and so cache the entire text. If you want to
    * avoid this, use {@link getHash | `getHash`} combined with a TextDecoder.
 
+   * @param fileName - the logical file name (see {@link getHash})
    * @param hash - the hash to get text for
    * @returns the text
    */
-  getText(hash: string): Promise<string>;
+  getText(fileName: string, hash: string): Promise<string>;
 
   /**
    * get the entries associated with a list hash
@@ -789,10 +793,12 @@ export interface RawRemarkableApi {
    * A list hash is the root hash, or any hash with the type 80000000. NOTE
    * these are hashed differently than files.
 
+   * @param fileName - `"root.docSchema"` for the root, or `"<id>.docSchema"`
+   *   for a sub-document's entry index
    * @param hash - the hash to get entries for
    * @returns the entries
    */
-  getEntries(hash: string): Promise<Entries>;
+  getEntries(fileName: string, hash: string): Promise<Entries>;
 
   /**
    * get the parsed and validated `Content` of a content hash
@@ -800,10 +806,11 @@ export interface RawRemarkableApi {
    * Use {@link getText | `getText`} combined with `JSON.parse` to bypass
    * validation
 
+   * @param fileName - typically `"<id>.content"`
    * @param hash - the hash to get Content for
    * @returns the content
    */
-  getContent(hash: string): Promise<Content>;
+  getContent(fileName: string, hash: string): Promise<Content>;
 
   /**
    * get the parsed and validated `Metadata` of a metadata hash
@@ -811,10 +818,11 @@ export interface RawRemarkableApi {
    * Use {@link getText | `getText`} combined with `JSON.parse` to bypass
    * validation
 
+   * @param fileName - typically `"<id>.metadata"`
    * @param hash - the hash to get Metadata for
    * @returns the metadata
    */
-  getMetadata(hash: string): Promise<Metadata>;
+  getMetadata(fileName: string, hash: string): Promise<Metadata>;
 
   /**
    * update the current root hash
@@ -994,26 +1002,27 @@ export class RawRemarkable implements RawRemarkableApi {
     }
   }
 
-  async #getHash(hash: string): Promise<Uint8Array> {
+  async #getHash(fileName: string, hash: string): Promise<Uint8Array> {
     if (!hashReg.test(hash)) {
       throw new ValidationError(hash, hashReg, "hash was not a valid hash");
     }
     const resp = await this.#authedFetch(
       "GET",
       `${this.#rawHost}/sync/v3/files/${hash}`,
+      { headers: { "rm-filename": fileName } },
     );
     // TODO switch to `.bytes()`.
     const raw = await resp.arrayBuffer();
     return new Uint8Array(raw);
   }
 
-  async getHash(hash: string): Promise<Uint8Array> {
+  async getHash(fileName: string, hash: string): Promise<Uint8Array> {
     const cached = this.#cache.get(hash);
     if (cached != null) {
       const enc = new TextEncoder();
       return enc.encode(cached);
     } else {
-      const res = await this.#getHash(hash);
+      const res = await this.#getHash(fileName, hash);
       // mark that we know hash exists
       const cacheVal = this.#cache.get(hash);
       if (cacheVal === undefined) {
@@ -1023,13 +1032,13 @@ export class RawRemarkable implements RawRemarkableApi {
     }
   }
 
-  async getText(hash: string): Promise<string> {
+  async getText(fileName: string, hash: string): Promise<string> {
     const cached = this.#cache.get(hash);
     if (cached != null) {
       return cached;
     } else {
       // NOTE two simultaneous requests will fetch twice
-      const raw = await this.#getHash(hash);
+      const raw = await this.#getHash(fileName, hash);
       const dec = new TextDecoder();
       const res = dec.decode(raw);
       this.#cache.set(hash, res);
@@ -1037,8 +1046,8 @@ export class RawRemarkable implements RawRemarkableApi {
     }
   }
 
-  async getEntries(hash: string): Promise<Entries> {
-    const rawFile = await this.getText(hash);
+  async getEntries(fileName: string, hash: string): Promise<Entries> {
+    const rawFile = await this.getText(fileName, hash);
     const [version, ...rest] = rawFile.slice(0, -1).split("\n");
     if (version === "3") {
       return { entries: rest.map(parseRawEntryLine) };
@@ -1069,8 +1078,8 @@ export class RawRemarkable implements RawRemarkableApi {
     }
   }
 
-  async getContent(hash: string): Promise<Content> {
-    const raw = await this.getText(hash);
+  async getContent(fileName: string, hash: string): Promise<Content> {
+    const raw = await this.getText(fileName, hash);
     const loaded = JSON.parse(raw) as unknown;
 
     // jtd can't verify non-discriminated unions, in this case, we have fileType
@@ -1092,8 +1101,8 @@ export class RawRemarkable implements RawRemarkableApi {
     throw new Error(`invalid content: ${joined}`);
   }
 
-  async getMetadata(hash: string): Promise<Metadata> {
-    const raw = await this.getText(hash);
+  async getMetadata(fileName: string, hash: string): Promise<Metadata> {
+    const raw = await this.getText(fileName, hash);
     const loaded = JSON.parse(raw) as unknown;
     if (!metadata.guardAssert(loaded)) throw Error("invalid metadata");
     return loaded;
@@ -1133,8 +1142,8 @@ export class RawRemarkable implements RawRemarkableApi {
   }
 
   async #putFile(
-    hash: string,
     fileName: string,
+    hash: string,
     bytes: Uint8Array,
   ): Promise<void> {
     // if the hash is already in the cache, writing is pointless
@@ -1171,7 +1180,7 @@ export class RawRemarkable implements RawRemarkableApi {
       subfiles: 0,
       size: bytes.length,
     };
-    return [res, this.#putFile(hash, id, bytes)];
+    return [res, this.#putFile(id, hash, bytes)];
   }
 
   async putText(id: string, text: string): Promise<[RawEntry, Promise<void>]> {
@@ -1252,11 +1261,7 @@ export class RawRemarkable implements RawRemarkableApi {
       subfiles: entries.length,
       size,
     };
-    return [
-      res,
-      // NOTE when monitoring requests, this had the extension .docSchema appended, but I'm not entirely sure why
-      this.#putFile(hash, `${id}.docSchema`, entryBuff),
-    ];
+    return [res, this.#putFile(`${id}.docSchema`, hash, entryBuff)];
   }
 
   async uploadFile(


### PR DESCRIPTION

reMarkable's sync v3 file endpoint now strictly validates the
rm-filename HTTP header on both reads and writes.
