### PR TITLE
fix: accept null for legacy metadata fields

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -272,6 +272,29 @@ ${realHash}:0:doc.metadata:0:1
     expect(meta).toEqual(metadata);
   });
 
+  test("#getMetadata() accepts null legacy boolean fields", async () => {
+    const realHash = repHash("1");
+    const file = `3
+${realHash}:0:doc.metadata:0:1
+`;
+    const metadata: Metadata = {
+      lastModified: "0",
+      visibleName: "name",
+      parent: "",
+      type: "DocumentType",
+      pinned: false,
+      deleted: null,
+      metadatamodified: null,
+      modified: null,
+      synced: null,
+    };
+    mockFetch(emptyResponse(), textResponse(file), jsonResponse(metadata));
+
+    const api = await remarkable("");
+    const meta = await api.getMetadata({ id: "test-id", hash: repHash("0") });
+    expect(meta).toEqual(metadata);
+  });
+
   test("#listIds()", async () => {
     const file = `3
 hash:80000000:document:0:1

--- a/src/raw.ts
+++ b/src/raw.ts
@@ -632,7 +632,7 @@ export interface Metadata {
   /** creation time, a string of the epoch timestamp */
   createdTime?: string;
   /** [speculative] true if the item has been actually deleted */
-  deleted?: boolean;
+  deleted?: boolean | null;
   /** the last modify time, the string of the epoch timestamp */
   lastModified?: string;
   /** the last opened epoch timestamp, isn't defined for CollectionType */
@@ -640,9 +640,9 @@ export interface Metadata {
   /** the last page opened, isn't defined for CollectionType, starts at 0*/
   lastOpenedPage?: number;
   /** [speculative] true if the metadata has been modified */
-  metadatamodified?: boolean;
+  metadatamodified?: boolean | null;
   /** [speculative] true if the item has been modified */
-  modified?: boolean;
+  modified?: boolean | null;
   /**
    * the id of the parent collection
    *
@@ -653,7 +653,7 @@ export interface Metadata {
   /** true of the item is starred */
   pinned: boolean;
   /** [unknown] */
-  synced?: boolean;
+  synced?: boolean | null;
   /**
    * the type of item this corresponds to
    *
@@ -685,10 +685,10 @@ const metadata: z.ZodType<Metadata> = z
     lastOpened: z.string().optional(),
     lastOpenedPage: z.number().int().optional(),
     createdTime: z.string().optional(),
-    deleted: z.boolean().optional(),
-    metadatamodified: z.boolean().optional(),
-    modified: z.boolean().optional(),
-    synced: z.boolean().optional(),
+    deleted: z.boolean().nullish(),
+    metadatamodified: z.boolean().nullish(),
+    modified: z.boolean().nullish(),
+    synced: z.boolean().nullish(),
     version: z.number().int().nonnegative().optional(),
     new: z.boolean().optional(),
     source: z.string().optional(),


### PR DESCRIPTION

fixes #96
